### PR TITLE
[finish]ログイン時、非ログイン時で切り替わるヘッダーを実装

### DIFF
--- a/app/views/layouts/_login_header.html.erb
+++ b/app/views/layouts/_login_header.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <nav class="navbar navbar-expand-md navbar-light bg-light rounded-bottom fixed-top">
+        <%= link_to "SKILL BARTER", root_path, class: "navbar-brand"%>
+          <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse justify-content-end" id="Navbar">
+        <ul class="navbar-nav">
+          <li class="nav-item active">
+            <%= link_to mypage_users_path, class: "nav-link" do %>
+              <span class="sr-only">(現位置)</span>マイページ
+            <% end %>
+          </li>
+          <li class="nav-item active">
+            <%= link_to destroy_user_session_path, method: :delete, class: "nav-link" do %>
+              <span class="sr-only">(現位置)</span>ログアウト
+            <% end %>
+          </li>
+        </ul>
+      </div>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_not_logged_in_header.html.erb
+++ b/app/views/layouts/_not_logged_in_header.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <nav class="navbar navbar-expand-md navbar-light bg-light rounded-bottom fixed-top">
+        <%= link_to "SKILL BARTER", root_path, class: "navbar-brand"%>
+          <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+
+      <div class="collapse navbar-collapse justify-content-end" id="Navbar">
+        <ul class="navbar-nav">
+          <li class="nav-item active">
+            <%= link_to new_user_session_path, class: "nav-link" do %>
+              <span class="sr-only">(現位置)</span>ログイン
+            <% end %>
+          </li>
+          <li class="nav-item active">
+            <%= link_to new_user_registration_path, class: "nav-link" do %>
+              <span class="sr-only">(現位置)</span>新規登録
+            <% end %>
+          </li>
+        </ul>
+      </div>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,15 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
+  <body style="padding-top: 4.5rem;">
+    <header>
+      <% if user_signed_in? %>
+        <%= render 'layouts/login_header' %>
+      <% else %>
+        <%= render 'layouts/not_logged_in_header' %>
+      <% end %>
+    </header>
+
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
・非ログイン時
ロゴ(トップへリンク)、ログイン、新規会員登録

・ログイン時
ロゴ(トップへリンク)、マイページ、ログアウト

ひとまずログイン状態での切り替わり、リンクの遷移は確認済み。
パソコンの画面で左右に大きく広がる。細かい修正はレイアウトを整える際に実施予定。