### PR TITLE
[finish]申請処理、(レビュー作成処理)の修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,8 +8,8 @@ class CommentsController < ApplicationController
     else
       @proposition = Proposition.find(params[:proposition_id])
       if @proposition.offering_to?
-        @offer = @proposition.my_offer
-        @offering_proposition = Proposition.find(@offer.offering_id)
+        @offering_proposition = @proposition.my_offering_proposition
+        @offer = @offering_proposition.offering_relationship
       end
       @comments = @proposition.comments
       @user = @proposition.user

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
       redirect_to proposition_path(params[:proposition_id].to_i)
     else
       @proposition = Proposition.find(params[:proposition_id])
-      if @proposition.offering?
+      if @proposition.offering_to?
         @offer = @proposition.my_offer
         @offering_proposition = Proposition.find(@offer.offering_id)
       end

--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -15,8 +15,8 @@ class PropositionsController < ApplicationController
   def show
     @proposition = Proposition.find(params[:id])
     if @proposition.offering_to?
-      @offer = @proposition.my_offer
-      @offering_proposition = Proposition.find(@offer.offering_id)
+      @offering_proposition = @proposition.my_offering_proposition
+      @offer = @offering_proposition.offering_relationship
     end
     @comments = @proposition.comments
     @comment = Comment.new

--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -14,7 +14,7 @@ class PropositionsController < ApplicationController
 
   def show
     @proposition = Proposition.find(params[:id])
-    if @proposition.offering?
+    if @proposition.offering_to?
       @offer = @proposition.my_offer
       @offering_proposition = Proposition.find(@offer.offering_id)
     end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,10 +1,6 @@
 class ReviewsController < ApplicationController
   def new
     @proposition = Proposition.find(params[:proposition_id])
-    # 「スキル交換を完了する」ボタンから来ているので、ここでbarter_statusを"bartered"に変更。
-    @proposition.barter_status = "bartered"
-    @proposition.save
-
     @review = Review.new
   end
 
@@ -12,8 +8,13 @@ class ReviewsController < ApplicationController
     @review = Review.new(review_params)
     @review.user_id = current_user.id
     @review.proposition_id = params[:proposition_id].to_i
-
     if @review.save
+      # 状況に合わせて案件の交換ステータスを自動更新。
+      reviewed_proposition = @review.proposition
+      reviewers_bartering_proposition = reviewed_proposition.offering
+      reviewed_proposition.auto_update_barter_status
+      reviewers_bartering_proposition.auto_update_barter_status
+
       redirect_to proposition_path(params[:proposition_id].to_i), success: "レビューの作成に成功しました。"
     else
       @proposition = Proposition.find(params[:proposition_id])

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -9,8 +9,4 @@ class Offer < ApplicationRecord
     validates :offering_id, uniqueness: true
     validates :offered_id
   end
-
-  def matched?
-    Offer.exists?(offering_id: offered_id, offered_id: offering_id)
-  end
 end

--- a/app/models/proposition.rb
+++ b/app/models/proposition.rb
@@ -45,7 +45,7 @@ class Proposition < ApplicationRecord
   end
 
   # 案件に自分(current_user)が申請を出しているかを判定する。
-  def offering?
+  def offering_to?
     # ログインユーザーの案件一覧を取得
     current_user_propositions = User.current.propositions
     # 上記をidに変更。(offering_propositionで使うので@を付与)
@@ -63,7 +63,7 @@ class Proposition < ApplicationRecord
 
   # 案件に申請を出している自分の案件を取得
   def my_offer
-    if offering?
+    if offering_to?
       # 1つしか無いはず。要リファクタリング。
       offering_proposition_id = (@current_user_proposition_ids & @offers_id)[0]
       Offer.find_by(offering_id: offering_proposition_id)

--- a/app/models/proposition.rb
+++ b/app/models/proposition.rb
@@ -15,23 +15,23 @@ class Proposition < ApplicationRecord
   has_many :chat_messages, dependent: :destroy
   has_one :review, dependent: :destroy
 
-  has_many :offering_relationship, class_name: "Offer",
-                                   foreign_key: "offering_id",
-                                   dependent: :destroy
-  has_many :offered_relationship, class_name: "Offer",
-                                  foreign_key: "offered_id",
+  has_one :offering_relationship, class_name: "Offer",
+                                  foreign_key: "offering_id",
                                   dependent: :destroy
-  has_many :offering, through: :offering_relationship, source: :offered
-  has_many :offerers, through: :offered_relationship, source: :offering
+  has_many :offered_relationships, class_name: "Offer",
+                                   foreign_key: "offered_id",
+                                   dependent: :destroy
+  has_one :offering, through: :offering_relationship, source: :offered
+  has_many :offerers, through: :offered_relationships, source: :offering
 
   enum barter_status: {
-    # 未マッチング かつ 未申請
+    # 未マッチング かつ 未スキル交換申請
     matching: 1,
-    # 申請中
+    # スキル交換申請中
     offering: 2,
     # マッチング済
     matched: 3,
-    # 交換完了申請中(自分だけ交換完了ボタンを押している。)
+    # 交換完了申請中(自分だけレビューを書いている。)
     bartering: 4,
     # 交換済み(履歴へ)
     bartered: 5,
@@ -44,46 +44,79 @@ class Proposition < ApplicationRecord
     validates :barter_status
   end
 
-  # 案件に自分(current_user)が申請を出しているかを判定する。
+  # 案件(self)に自分(current_user)がスキル交換申請を出しているかを判定する。
   def offering_to?
-    # ログインユーザーの案件一覧を取得
-    current_user_propositions = User.current.propositions
-    # 上記をidに変更。(offering_propositionで使うので@を付与)
-    @current_user_proposition_ids = current_user_propositions.map(&:id)
+    # 案件(self)にスキル交換申請を出しているユーザー一覧を取得
+    offerer_users = offerers.map(&:user)
+    # 上記一覧に自分が入っているかで確認。
+    offerer_users.include?(User.current)
+    # 自分の案件のid一覧を取得(offering_propositionで使うので@を付与)
+    # @current_user_propositions_ids = User.current.propositions.map(&:id)
 
-    # 案件に来ているoffer一覧を取得
-    offers = Offer.where(offered_id: id)
-    # 上記をoffering_idの一覧に(offering_propositionで使うので@を付与)
-    @offers_id = offers.map(&:offering_id)
+    # 案件(self)に来ているofferのid一覧を取得(offering_propositionで使うので@を付与)
+    # @offers_id = offerers.map(&:id)
 
     # current_user_proposition_idsとoffers_idに重複する要素があるか(空集合になっていないか)どうかで判定
     # あればオファーしているということ。
-    @current_user_proposition_ids & @offers_id != []
+    # @current_user_proposition_ids & @offers_id != []
   end
 
-  # 案件に申請を出している自分の案件を取得
-  def my_offer
-    if offering_to?
-      # 1つしか無いはず。要リファクタリング。
-      offering_proposition_id = (@current_user_proposition_ids & @offers_id)[0]
-      Offer.find_by(offering_id: offering_proposition_id)
-    end
+  # 案件(self)に出している自分の申請(offer)を取得
+  def my_offering_proposition
+    # スキル交換申請が来ている案件の中で、そのユーザーが自分のものを取得。1つしか無いはず。
+    offerers.select { |offerer| offerer.user == User.current }.pop
   end
 
-  # 相互offerになっているかを確認
+  # 案件(self)で申請を出しているかを判定。
+  def offering?
+    offering.present?
+  end
+
+  # マッチング済みかどうかを判定。offerしている相手のoffer相手が自分になっているかで確認。
   def matched?
-    offering == offered
+    self == offering.offering if offering.present?
   end
 
-  # offerの状況に応じてbarter_statusを自動更新する。
-  # 相互にoffer: barter_statusをmatchedに。
-  # 相互offerになっていない: barter_statusをmatchingに。
-  def auto_update_barter_status
-    # 相互オファーになっているか
-    if matched?
-      self.barter_status = "matched"
+  # 交換完了申請中かどうか( 案件(self)のオーナーだけがレビューを書いている状態か )を判定。
+  def bartering?
+    if offering.present?
+      owner_review = Review.find_by(user_id: user.id, proposition_id: offering.id)
+      opponent_review = Review.find_by(user_id: offering.user.id, proposition_id: id)
     else
-      self.barter_status = "matching"
+      owner_review = nil
+      opponent_review = nil
+    end
+
+    owner_review.present? && opponent_review.blank?
+  end
+
+  # スキル交換が完了しているか(お互いレビューを書いたか)を判定。
+  def bartered?
+    if offering.present?
+      owner_review = Review.find_by(user_id: user.id, proposition_id: offering.id)
+      opponent_review = Review.find_by(user_id: offering.user.id, proposition_id: id)
+    else
+      owner_review = nil
+      opponent_review = nil
+    end
+
+    owner_review.present? && opponent_review.present?
+  end
+
+  # 状況に応じてbarter_statusを自動更新する。
+  def auto_update_barter_status
+    if bartered?
+      update(barter_status: "bartered")
+    elsif bartering?
+      update(barter_status: "bartering")
+    elsif matched?
+      update(barter_status: "matched")
+      offering.update(barter_status: "matched")
+    elsif offering?
+      update(barter_status: "offering")
+    # 交換申請を取り下げた場合に該当
+    else
+      update(barter_status: "matching")
     end
   end
 end

--- a/app/models/proposition.rb
+++ b/app/models/proposition.rb
@@ -25,12 +25,16 @@ class Proposition < ApplicationRecord
   has_many :offerers, through: :offered_relationship, source: :offering
 
   enum barter_status: {
-    # 未マッチング
+    # 未マッチング かつ 未申請
     matching: 1,
+    # 申請中
+    offering: 2,
     # マッチング済
-    matched: 2,
+    matched: 3,
+    # 交換完了申請中(自分だけ交換完了ボタンを押している。)
+    bartering: 4,
     # 交換済み(履歴へ)
-    bartered: 3,
+    bartered: 5,
   }
 
   with_options presence: true do

--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -12,14 +12,14 @@
   <% end %>
 
   <%# 既にスキル交換申請済みの場合は申請している自分の案件名を表示 %>
-  <% if proposition.offering? %>
+  <% if proposition.offering_to? %>
     <p>スキル交換申請中</p>
     <span>案件名：　</span><%= @offering_proposition.title %>
   <% end %>
 
   <%# 既にスキル交換申請済みの場合は"交換申請を取り下げる"ボタンにする。 %>
   <div class="actions mx-auto" style="width: 200px;">
-    <% if proposition.offering? %>
+    <% if proposition.offering_to? %>
       <%= link_to "交換申請を取り下げる",  proposition_offer_path(proposition.id, offer.id), method: :delete, class: "btn btn-outline-danger btn-block" %>
     <% else %>
       <%= link_to "スキル交換申請", offer_propositions_path(offered_id: proposition.id), class: "btn btn-info btn-block"%>

--- a/app/views/reviews/_proposition_review.html.erb
+++ b/app/views/reviews/_proposition_review.html.erb
@@ -2,7 +2,7 @@
 
 <div class="review-card col-md-12 rounded-lg">
   <%# 交換が完了していない場合は交換完了確認 %>
-  <% if proposition.barter_status != "bartered" %>
+  <% if proposition.my_offering_proposition.barter_status != "bartering" && proposition.my_offering_proposition.barter_status != "bartered" %>
     <div class="row">
       <div class="col-md-12 d-flex align-items-center sentence">
       スキル交換を完了後はレビュー作成ページへ移動します。<br >
@@ -15,7 +15,7 @@
       </div>
     </div>
 
-  <%# 交換が完了している場合はレビューを表示 %>
+  <%# レビューを作成済みの場合はレビューを表示 %>
   <% else %>
     <%# レビュー編集ボタン。レビューしたユーザーにのみ表示。 %>
     <div class="row">


### PR DESCRIPTION
メソッドにバグが有り上手く処理がなされない場合があった。

・交換ステータス(barter_status)の種類を追加
・交換ステータスを自動更新するために各種メソッドを追加
・申請時、申請取り下げ時、レビュー作成時に自動で案件の交換ステータスが更新されるよう処理を修正
・メソッド、交換ステータスの種類増加に伴い、該当の処理、ビューファイルを修正