### PR TITLE
[finish]レビューの表示条件のバグを修正。

### DIFF
--- a/app/models/proposition.rb
+++ b/app/models/proposition.rb
@@ -66,6 +66,11 @@ class Proposition < ApplicationRecord
     matched? && offering.user == User.current
   end
 
+  # 案件(self)がレビューされているかどうかを判定する。
+  def is_reviewed?
+    !!review
+  end
+
   # 案件(self)に出している自分の申請(offer)を取得
   def my_offering_proposition
     # スキル交換申請が来ている案件の中で、そのユーザーが自分のものを取得。1つしか無いはず。

--- a/app/models/proposition.rb
+++ b/app/models/proposition.rb
@@ -61,6 +61,11 @@ class Proposition < ApplicationRecord
     # @current_user_proposition_ids & @offers_id != []
   end
 
+  # 案件(self)と自分(current_user)の案件がマッチしているかを判定する。
+  def matched_with?
+    matched? && offering.user == User.current
+  end
+
   # 案件(self)に出している自分の申請(offer)を取得
   def my_offering_proposition
     # スキル交換申請が来ている案件の中で、そのユーザーが自分のものを取得。1つしか無いはず。

--- a/app/views/propositions/show.html.erb
+++ b/app/views/propositions/show.html.erb
@@ -11,12 +11,15 @@
           <li class="nav-item" role="presentation">
             <a href="#home" id="home-tab" class="nav-link active" role="tab" data-toggle="tab" aria-controls="home" aria-selected="true">詳細</a>
           </li>
-          <li class="nav-item" role="presentation">
-            <a href="#profile" id="profile-tab" class="nav-link" role="tab" data-toggle="tab" aria-controls="profile" aria-selected="false">チャット</a>
-          </li>
-          <li class="nav-item" role="presentation">
-            <a href="#contact" id="contact-tab" class="nav-link" role="tab" data-toggle="tab" aria-controls="contact" aria-selected="false">レビュー</a>
-          </li>
+          <%# マッチングしていない場合はチャット、レビュータグは表示しない。 %>
+          <% if @proposition.matched? %>
+            <li class="nav-item" role="presentation">
+              <a href="#profile" id="profile-tab" class="nav-link" role="tab" data-toggle="tab" aria-controls="profile" aria-selected="false">チャット</a>
+            </li>
+            <li class="nav-item" role="presentation">
+              <a href="#contact" id="contact-tab" class="nav-link" role="tab" data-toggle="tab" aria-controls="contact" aria-selected="false">レビュー</a>
+            </li>
+          <% end %>
         </ul>
 
         <%# パネル部分 %>

--- a/app/views/reviews/_proposition_review.html.erb
+++ b/app/views/reviews/_proposition_review.html.erb
@@ -1,22 +1,9 @@
 <%# 交換を完了しているか否かで表示する内容を変更 %>
 
 <div class="review-card col-md-12 rounded-lg">
-  <%# 交換が完了していない場合は交換完了確認 %>
-  <% if proposition.my_offering_proposition.barter_status != "bartering" && proposition.my_offering_proposition.barter_status != "bartered" %>
-    <div class="row">
-      <div class="col-md-12 d-flex align-items-center sentence">
-      スキル交換を完了後はレビュー作成ページへ移動します。<br >
-      レビューを作成すると、ここにレビュー内容が表示されます。
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-8 offset-md-2 d-flex align-items-center">
-        <%= link_to "スキル交換を完了する", new_proposition_review_path(proposition.id), "data-confirm" => "この操作は取り消せません。\nスキル交換を完了してよろしいですか？", class: "btn btn-info btn-block" %>
-      </div>
-    </div>
+  <%# レビューされている場合。レビュー内容を表示 %>
+  <% if proposition.is_reviewed? %>
 
-  <%# レビューを作成済みの場合はレビューを表示 %>
-  <% else %>
     <%# レビュー編集ボタン。レビューしたユーザーにのみ表示。 %>
     <div class="row">
       <div class="col-md-9">
@@ -47,6 +34,28 @@
     <div class="row d-flex align-items-center sentence">
       <div class="col-md-12">
         <%= review.comment %>
+      </div>
+    </div>
+
+  <%# マッチングしているユーザーで、レビュー前の場合。スキル交換完了申請ボタンを表示 %>
+  <% elsif proposition.matched_with? %>
+    <div class="row">
+      <div class="col-md-12 d-flex align-items-center sentence">
+      スキル交換を完了後はレビュー作成ページへ移動します。<br >
+      レビューを作成すると、ここにレビュー内容が表示されます。
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-8 offset-md-2 d-flex align-items-center">
+        <%= link_to "スキル交換を完了する", new_proposition_review_path(proposition.id), "data-confirm" => "この操作は取り消せません。\nスキル交換を完了してよろしいですか？", class: "btn btn-info btn-block" %>
+      </div>
+    </div>
+
+  <%# マッチングしていない、またはマッチングしたユーザーでない場合。 %>
+  <% else %>
+    <div class="row">
+      <div class="col-md-12 d-flex align-items-center sentence">
+      レビューが作成されると、ここにレビュー内容が表示されます。
       </div>
     </div>
 


### PR DESCRIPTION
マッチング前またはマッチングしたユーザーでない場合の条件を用意していなかったためエラーが出ていた。
条件を整え、表示内容を用意。

併せて、マッチングされていない案件の場合はチャット、レビュータグは表示されないよう修正