### PR TITLE
[fix]blocker, blockedの外部キー参照先をusersに修正。

### DIFF
--- a/db/migrate/20200521105357_create_blocks.rb
+++ b/db/migrate/20200521105357_create_blocks.rb
@@ -1,8 +1,8 @@
 class CreateBlocks < ActiveRecord::Migration[5.2]
   def change
     create_table :blocks do |t|
-      t.references :blocker, null: false, foreign_key: true
-      t.references :blocked, null: false, foreign_key: true
+      t.references :blocker, null: false, foreign_key: { to_table: :users }
+      t.references :blocked, null: false, foreign_key: { to_table: :users }
 
       t.timestamps
     end


### PR DESCRIPTION
foreign_key: trueのままにしてしまっていたので、本番環境でrails db:migrateを実行するとエラーが発生していた。

foreign_key: { to_table: :users }
に修正。