### PR TITLE
[fix]propositionテーブルマイグレーションファイルのintroductionカラムインデックスにlimit: 255を追加。

### DIFF
--- a/db/migrate/20200521105357_create_blocks.rb
+++ b/db/migrate/20200521105357_create_blocks.rb
@@ -1,8 +1,8 @@
 class CreateBlocks < ActiveRecord::Migration[5.2]
   def change
     create_table :blocks do |t|
-      t.references :blocker, null: false, foreign_key: true
-      t.references :blocked, null: false, foreign_key: true
+      t.references :blocker, null: false, foreign_key: { to_table: :users }
+      t.references :blocked, null: false, foreign_key: { to_table: :users }
 
       t.timestamps
     end

--- a/db/migrate/20200521110341_create_propositions.rb
+++ b/db/migrate/20200521110341_create_propositions.rb
@@ -12,7 +12,7 @@ class CreatePropositions < ActiveRecord::Migration[5.2]
     end
 
     add_index :propositions, :title
-    add_index :propositions, :introduction
+    add_index :propositions, :introduction, limit: 255
     add_index :propositions, :deadline
     add_index :propositions, :barter_status
   end


### PR DESCRIPTION
text型のカラムにインデックスを付与する際は255文字以内の制限が必要なので、introductionカラムのインデックスにlimit: 255を追加。