### PR TITLE
[fix]インデックスの文字数制限はlengthで付けるようなので修正。

### DIFF
--- a/db/migrate/20200521110341_create_propositions.rb
+++ b/db/migrate/20200521110341_create_propositions.rb
@@ -12,7 +12,7 @@ class CreatePropositions < ActiveRecord::Migration[5.2]
     end
 
     add_index :propositions, :title
-    add_index :propositions, :introduction, limit: 255
+    add_index :propositions, :introduction, length: 255
     add_index :propositions, :deadline
     add_index :propositions, :barter_status
   end


### PR DESCRIPTION
limit: 255 → length: 255　に変更。