### PR TITLE
[finish]certbot実装のための処理

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.action_cable.allowed_request_origins = [ 'http://13.112.212.82']
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
アクセスを強制的にhttpsへリダイレクトするよう設定のコメントアウトを外す。