### PR TITLE
[finish]案件編集ページを作成

### DIFF
--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -31,10 +31,10 @@
     <% end %>
 
     <%# 条件の入れ子は好ましくないが、どうしてもここは入れ子以外では表現できなかった。後程変更予定。 %>
-    <div class="actions mx-auto card-text mb-3" style="width: 200px;">
-      <%# 自分の案件には何も表示しない。%>
+    <div class="actions text-center card-text mb-3">
+      <%# 自分の案件には案件編集ページ %>
       <% if proposition.user == current_user %>
-
+        <%= link_to "編集する", edit_proposition_path(proposition.id), class: "btn btn-outline-success btn-block" %>
       <% elsif proposition.is_matched? %>
         <%# 案件がマッチング済みで、マッチングしているのも自分 %>
         <% if proposition.matched_with? %>

--- a/app/views/propositions/edit.html.erb
+++ b/app/views/propositions/edit.html.erb
@@ -1,2 +1,15 @@
-<h1>Propositions#edit</h1>
-<p>Find me in app/views/propositions/edit.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-md-3 bg-light">
+      <%= render 'layouts/global_navigation_side_bar' %>
+    </div>
+    <div class="col-md-9">
+      <div class="col-md-12">
+        <h4><strong>案件編集</strong></h4>
+      </div>
+      <div class="col-md-12 mt-4">
+        <%= render 'propositions/proposition_form', proposition: @proposition, form_target: "new_proposition", tag: @tag, submit_value: "編集完了" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/propositions/finish.html.erb
+++ b/app/views/propositions/finish.html.erb
@@ -1,13 +1,18 @@
+<% if @previous_path[:action] == "create" %>
+  <% provide :heading, "新規案件作成"%>
+<% elsif @previous_path[:action] == "edit" %>
+  <% provide :heading, "案件編集" %>
+<% end %>
+
 <div class="container">
   <div class="row">
     <div class="col-md-3">
       <%= render 'layouts/global_navigation_side_bar' %>
     </div>
     <div class="col-md-9">
-      <%# 活動状況一覧 %>
       <div class="row my-3">
         <div class="col-md-12">
-          <h5><strong>新規案件作成完了</strong></h5>
+          <h5><strong><%= yield(:heading) %>完了</strong></h5>
         </div>
 
         <div class="col-md-12 mt-2">


### PR DESCRIPTION
案件編集ページを作成。機能、ページ遷移確認済み。

また、proposition#finishページを編集完了後にも使用。それに伴い見出しを遷移元のページによって変更するよう修正。