### PR TITLE
[finish]ユーザー退会処理を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   # User.currentにcurrent_userを割り当てる。
   def set_current_user
+    # これが原因で退会済みユーザーでトップへredirectされていてもログインしてしまっている。後程変更予定。
     User.current = current_user
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,17 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    user = User.find_by(email: sign_in_params[:email])
+    if user.user_status == "unsubscribed"
+      # application_controllerのset_current_userにより自動的にログインしてしまっている様子なので、一度ログアウト処理を挟む。
+      # 後程変更予定。
+      sign_out user
+      redirect_to root_path, danger: "退会済みのユーザーです。"
+    else
+      super
+    end
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,13 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    user = User.find(params[:id])
+    if user.update(user_status: "unsubscribed")
+      sign_out user
+      redirect_to root_path, success: "退会処理が完了しました。"
+    else
+      redirect_to edit_user_path(current_user.id), danger: "退会処理に失敗しました。\nお手数ですが、運営にご連絡ください。"
+    end
   end
 
   def blocking

--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -32,8 +32,10 @@
 
     <%# 条件の入れ子は好ましくないが、どうしてもここは入れ子以外では表現できなかった。後程変更予定。 %>
     <div class="actions text-center card-text mb-3">
+      <%# ログインしていない場合は何も表示しない。 %>
+      <% if not user_signed_in? %>
       <%# 自分の案件には案件編集ページ %>
-      <% if proposition.user == current_user %>
+      <% elsif proposition.user == current_user %>
         <%= link_to "編集する", edit_proposition_path(proposition.id), class: "btn btn-outline-success btn-block" %>
       <% elsif proposition.is_matched? %>
         <%# 案件がマッチング済みで、マッチングしているのも自分 %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,8 +6,11 @@
     <div class="col-md-9">
       <%# ユーザー編集フォーム %>
       <div class="row bg-light py-2 my-2">
-        <div class="col-md-12">
+        <div class="col-md-9">
           <h5><strong>プロフィール</strong></h5>
+        </div>
+        <div class="col-md-3">
+          <%= link_to "退会する", user_path(current_user.id), method: :delete, class: "btn btn-outline-danger btn-block", "data-confirm" => "本当に退会しますか？" %>
         </div>
 
         <div class="col-md-12 mt-2">


### PR DESCRIPTION
・「退会する」ボタンを押したユーザーの退会処理を実装。
(user_statusを"unsubscribed"にして論理削除。)処理が正しく行われることは確認済み。

併せて
・退会していたユーザーがログインできないようログイン処理を修正。
・ログインしていないユーザーは案件詳細ページで申請関連ボタンが表示されないよう修正。
