### PR TITLE
[fix]ActionCableを本番環境で使用できるよう設定を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # ひとまずEIPで記載。後程変更予定。
-  config.action_cable.allowed_request_origins = [ 'https://skill-barter.com/', /http:\/\/skill-barter.*/ ]
+  config.action_cable.allowed_request_origins = [ 'https://skill-barter.com/', /https:\/\/skill-barter.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true


### PR DESCRIPTION
cnfig.aciton_cable.allowed_request_originsのドメイン名をhttpsに修正。