### PR TITLE
[finish]案件削除処理を追加。

### DIFF
--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -124,7 +124,7 @@ class PropositionsController < ApplicationController
           offerer.auto_update_barter_status
         end
       end
-      redirect_to request.referer, success: "案件の削除に成功しました。"
+      redirect_to mypage_index_propositions_path, success: "案件の削除に成功しました。"
     end
   end
 

--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -111,6 +111,21 @@ class PropositionsController < ApplicationController
   end
 
   def destroy
+    proposition = Proposition.find(params[:id])
+    if proposition.is_matched?
+      redirect_to request.referer, warning: "マッチングしている案件は削除できません。"
+    else
+      # 削除すると関連するofferも消えるので、申請が来ていた案件のステータスを削除後に更新。
+      # ここで取っておかないと、削除後はofferersが空になってしまう。to_aとしないと同じく消えてしまう。
+      update_needed_propositions = proposition.offerers.to_a
+      proposition.destroy!
+      if update_needed_propositions.present?
+        update_needed_propositions.each do |offerer|
+          offerer.auto_update_barter_status
+        end
+      end
+      redirect_to request.referer, success: "案件の削除に成功しました。"
+    end
   end
 
   def mypage_index

--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -72,7 +72,8 @@
       <% if not user_signed_in? %>
       <%# 自分の案件には案件編集ページ %>
       <% elsif proposition.user == current_user %>
-        <%= link_to "編集する", edit_proposition_path(proposition.id), class: "btn btn-outline-success btn-block" %>
+        <%= link_to "編集する", edit_proposition_path(proposition.id), class: "btn btn-success btn-block" %>
+        <%= link_to "削除する", proposition_path(proposition.id), method: :delete, class: "btn btn-outline-danger btn-block" %>
       <% elsif proposition.is_matched? %>
         <%# 案件がマッチング済みで、マッチングしているのも自分 %>
         <% if proposition.matched_with? %>


### PR DESCRIPTION
案件削除機能を追加。マッチングしている場合は案件を削除できない。また、削除後は申請が来ていた案件のステータスを自動更新するように。正しく機能、ページ遷移することは確認済み。