### PR TITLE
[finish]案件申請ページのバグを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,14 +21,4 @@ class ApplicationController < ActionController::Base
     # これが原因で退会済みユーザーでトップへredirectされていてもログインしてしまっている。後程変更予定。
     User.current = current_user
   end
-
-  # propositions#offerはインスタンス変数が多く、様々なところでrenderしているのでメソッドを定義
-  def instance_variables_for_propositions_offer
-    @offer ||= Offer.new
-    @new_proposition ||= Proposition.new
-    @propositions ||= Proposition.where(user_id: current_user.id, barter_status: "matching")
-    # 案件詳細ページから申請を出したい相手の案件idをoffered_idとして送ってある。他のアクションからrenderする際は別途用意。
-    @offered_proposition ||= Proposition.find(params[:offered_id])
-    @tag ||= Tag.new
-  end
 end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -4,24 +4,20 @@ class OffersController < ApplicationController
   # before_action :authenticate_right_user_for_destroy, only: [:destroy]
 
   def create
-    # 値を一部入力していてrenderした時用に、ここで@new_propositionを作成。
-    @proposition_id = params.to_unsafe_h.key("申請")
-    @new_proposition = Proposition.new(proposition_params)
-    @new_proposition.user_id = current_user.id
     @offered_proposition = Proposition.find(params[:proposition_id])
-
-    # radio_numberのみ
-    @offer = Offer.new(offer_params)
-    # URLのparams[:proposition_id]は申請を出したい相手の案件id
-    @offer.offered_id = params[:proposition_id].to_i
-
-    # radio_numberの値で選択されていたラジオボタンを判別
-    case @offer.radio_number.to_i
-
-    # 「案件を新規に作成して申請する」が選択されていた場合
-    when 1
-      # まず案件、案件カテゴリ、要望カテゴリ全て必要な値が揃っているかを確認する。
-
+    if params[:offering_proposition_id].present?
+      offering_proposition = Proposition.find(offering_proposition_id.to_i)
+      Offer.create!(
+        offering_id: offering_proposition.id,
+        offered_id: @offered_proposition.id,
+      )
+      creating_room_and_update_barter_statuses(offering_proposition)
+      flash[:success] = "申請に成功しました。"
+      redirect_to proposition_path(@offered_proposition.id)
+    else
+      @new_proposition = Proposition.new(proposition_params)
+      @new_proposition.user_id = current_user.id
+      # 案件、案件カテゴリ、要望カテゴリ全て必要な値が揃っているかを確認する。
       # if文の条件文に書くと長すぎるのでここで変数にする。
       is_proposition_category_selected = @new_proposition.proposition_category_tag_id.present?
       is_request_category_selected = @new_proposition.request_category_tag_id.present?
@@ -30,46 +26,25 @@ class OffersController < ApplicationController
       if @new_proposition.valid? && is_proposition_category_selected && is_request_category_selected
         # 全て揃っていることを確認してようやく案件、案件カテゴリ、要望カテゴリ、スキル交換申請を保存。
         @new_proposition.save
-        PropositionCategory.create(
+        PropositionCategory.create!(
           proposition_id: @new_proposition.id,
           tag_id: @new_proposition.proposition_category_tag_id.to_i
         )
-        RequestCategory.create(
+        RequestCategory.create!(
           proposition_id: @new_proposition.id,
-          tag_id: @new_proposition.request_category_tag_id.to_i
+          tag_id: @new_proposition.request_category_tag_id.to_i,
         )
-        # 案件を新規に作成する場合はoffering_idが空なので、ここで入れて保存。
-        @offer.offering_id = @new_proposition.id
-        @offer.save
-
+        Offer.create!(
+          offering_id: @new_proposition.id,
+          offered_id: @offered_proposition.id,
+        )
         creating_room_and_update_barter_statuses(@new_proposition)
-
-        flash[:success] = "案件の申請に成功しました。"
-        redirect_to proposition_path(params[:proposition_id].to_i)
-
-      # 必要なパラメータが不足している場合は申請用案件選択画面へ返す。
+        flash[:success] = "案件の新規作成と申請に成功しました。"
+        redirect_to proposition_path(@offered_proposition.id)
       else
-        # renderで必要なインスタンス変数を用意。
-        instance_variables_for_propositions_offer
+        @propositions = Proposition.where(user_id: current_user.id, barter_status: "matching")
         render 'propositions/offer'
       end
-
-    # 「既存の案件から申請する」が選択されていた場合
-    when 2
-      @offer.offering_id = offering_proposition_id
-      @offer.save
-
-      creating_room_and_update_barter_statuses(@offer.offering)
-
-      # 完了したら案件詳細画面へ
-      flash[:success] = "案件の申請に成功しました。"
-      redirect_to proposition_path(params[:proposition_id].to_i)
-
-    # (UIではできないようになっているが)ラジオボタンが選択されていなかった場合
-    else
-      # renderで必要なインスタンス変数を用意。
-      instance_variables_for_propositions_offer
-      render 'propositions/offer'
     end
   end
 
@@ -91,51 +66,29 @@ class OffersController < ApplicationController
 
   private
 
-  # 選んだラジオボタンに応じた番号がparams[:offer][:radio_number]として飛んできている。
-  # 他の値は他の方法で用意するしか無かったので、ひとまずここではradio_numberのみ。
-  def offer_params
-    params.require(:offer).permit(:radio_number)
-  end
-
-  # 新規案件作成フォームに入力した値
-  # 案件カテゴリとして選んだタグのidがparams[:proposition][:proposition_category_id]として飛んできている。
-  # 要望カテゴリとして選んだタグのidがparams[:proposition][:request_category_id]として飛んできている。
   def proposition_params
     params.require(:proposition).permit!
   end
 
-  # どの既存の案件の「申請」ボタンを押したのかによってoffering_idに入れる値を判別
-  # 押すボタンによって何がキーになって飛んでくるか分からないため、値が"申請"となっているキーを探す。
   def offering_proposition_id
-    # 後程変更予定
-    # paramsにはkeyメソッドが使えないため、一度ハッシュ化
-    # 本当はpermitしてからto_hしたいが、キーが何か分からないためpermitもできないので、やむを得ずto_unsafe_hashメソッドを使用。
-    params_hash = params.to_unsafe_hash
-    params_hash.key("申請")
-    # 上記の方法がセキュリティ上良くない、ということであれば以下の方法
-    # propositions = Proposition.where(user_id: current_user.id, barter_status: "matching")
-    # propositions.each do |proposition|
-    #   if params[:"#{proposition.id}"] == "申請"
-    #     proposition.id
-    #   end
-    # end
+    params.require(:offering_proposition_id)
   end
 
-  def creating_room_and_update_barter_statuses(proposition)
-    proposition.auto_update_barter_status
-    proposition.offering.auto_update_barter_status
+  def creating_room_and_update_barter_statuses(offering_proposition)
+    offering_proposition.auto_update_barter_status
+    offering_proposition.offering.auto_update_barter_status
     # マッチングしたらRoom, PropositionRoomを新規作成。
     # 以前一度マッチングしていればpropositon.roomが存在するはずで、その場合は新たには作成しないように。
-    if proposition.matched? && proposition.room.blank?
+    if offering_proposition.matched? && offering_proposition.room.blank?
       room = Room.create!
       # この案件とルームを関連付ける。
       PropositionRoom.create!(
-        proposition_id: proposition.id,
+        proposition_id: offering_proposition.id,
         room_id: room.id,
       )
       # マッチング相手の案件とルームを関連付ける。
       PropositionRoom.create!(
-        proposition_id: proposition.offering.id,
+        proposition_id: offering_proposition.offering.id,
         room_id: room.id,
       )
     end

--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -49,7 +49,6 @@ class PropositionsController < ApplicationController
 
   def new
     @proposition = Proposition.new
-    @tag = Tag.new
   end
 
   def edit
@@ -59,7 +58,6 @@ class PropositionsController < ApplicationController
     request_category = @proposition.request_categories[0]
     @proposition.proposition_category_tag_id = proposition_category.tag_id
     @proposition.request_category_tag_id = request_category.tag_id
-    @tag = Tag.new
   end
 
   def show
@@ -137,8 +135,9 @@ class PropositionsController < ApplicationController
   end
 
   def offer
-    # パラメータが多く、他でrenderされることも多いのでapplication_controllerに以下のメソッドを定義。
-    instance_variables_for_propositions_offer
+    @new_proposition = Proposition.new
+    @propositions = Proposition.where(user_id: current_user.id, barter_status: "matching")
+    @offered_proposition = Proposition.find(params[:offered_id])
   end
 
   def search

--- a/app/views/propositions/_proposition_form.html.erb
+++ b/app/views/propositions/_proposition_form.html.erb
@@ -1,11 +1,11 @@
 <%# propositions#offerでrenderされている場合について %>
 <%# attachmentがpropositionにしか設定されておらず、offerフォームに入れるとエラーが出るため、フォームを入れ子構造に %>
 <%# それぞれのformヘルパーにform: form_targetを付けて、offerフォームからはform_target: "new_proposition"値が送られるように。 %>
-<%= form_with(model: proposition, html: { id: "new_proposition", class: "needs-validation-proposition", novalidate: true }) do |form| %>
+<%= form_with(model: proposition, url: form_url, html: { class: "needs-validation-proposition", novalidate: true }) do |form| %>
   <div class="form-group row">
     <%= form.label :title, "案件タイトル", for: "validationCustom01", class: "col-md-2 col-form-label" %>
     <div class="col-md-10">
-      <%= form.text_field :title, autofocus: true, id: "validationCustom01", class: "form-control", form: form_target, required: true %>
+      <%= form.text_field :title, autofocus: true, id: "validationCustom01", class: "form-control", required: true %>
     <div class="invalid-feedback">
       タイトルを入力してください。
     </div>
@@ -15,7 +15,7 @@
   <div class="form-group row">
     <%= form.label :introduction, "案件説明文", for: "validationCustom02", class: "col-md-2 col-form-label" %>
     <div class="col-md-10">
-      <%= form.text_area :introduction, rows: 3, id: "validationCustom02", class: "form-control", form: form_target, required: true %>
+      <%= form.text_area :introduction, rows: 3, id: "validationCustom02", class: "form-control", required: true %>
     <div class="invalid-feedback">
       説明文を入力してください。
     </div>
@@ -25,21 +25,21 @@
   <div class="form-group row">
     <%= form.label :deadline, "締め切り", class: "col-md-2 col-form-label" %>
     <div class="col-md-10">
-      <%= form.date_field :deadline, class: "form-control", form: form_target %>
+      <%= form.date_field :deadline, class: "form-control" %>
     </div>
   </div>
 
   <div class="form-group row">
     <%= form.label :rendering_image, "完成イメージ画像", class: "col-md-2 col-form-label" %>
     <div class="col-md-10">
-      <%= form.file_field :rendering_image_id, class: "form-control", form: form_target, accept: "image/*" %>
+      <%= form.file_field :rendering_image_id, class: "form-control", accept: "image/*" %>
     </div>
   </div>
 
   <div class="form-group row">
     <%= form.label :proposition_category_tag_id, "案件カテゴリタグ", for: "validationCustom03", class: "col-md-2 col-form-label" %>
     <div class="col-md-5">
-      <%= form.collection_select :proposition_category_tag_id, Tag.all.order(name: "ASC"), :id, :name, { include_blank: "選択してください" }, { id: "validationCustom03", class: "custom-select", form: form_target, required: true } %>
+      <%= form.collection_select :proposition_category_tag_id, Tag.all.order(name: "ASC"), :id, :name, { include_blank: "選択してください" }, { id: "validationCustom03", class: "custom-select", required: true } %>
     <div class="invalid-feedback">
       案件カテゴリタグを選択してください。
     </div>
@@ -52,7 +52,7 @@
   <div class="form-group row">
     <%= form.label :request_category_tag_id, "要望カテゴリタグ", for: "validationCustom04", class: "col-md-2 col-form-label" %>
     <div class="col-md-5">
-      <%= form.collection_select :request_category_tag_id, Tag.all.order(name: "ASC"), :id, :name, { include_blank: "選択してください" }, { id: "validationCustom04", class: "custom-select", form: form_target, required: true } %>
+      <%= form.collection_select :request_category_tag_id, Tag.all.order(name: "ASC"), :id, :name, { include_blank: "選択してください" }, { id: "validationCustom04", class: "custom-select", required: true } %>
     <div class="invalid-feedback">
       要望カテゴリタグを選択してください。
     </div>
@@ -66,16 +66,16 @@
     <div class="col-md-9">
     </div>
     <div class="col-md-3">
-      <%= form.submit submit_value, class: "btn btn-primary btn-block", form: form_target %>
+      <%= form.submit submit_value, class: "btn btn-primary btn-block" %>
     </div>
   </div>
 <% end %>
 
 <%# これを置かないとtag_formのsubmitが効かない。上のform_withの中に置くとformタグが生成されないのでここに。 %>
 <%# また、案件カテゴリタグ用と要望カテゴリタグ用両方置いておかないと後に置いてある方の値しか飛ばしてくれない。。 %>
-<%= form_with(model: tag, url: tag_path, id: "new_proposition_category_tag") do |form| %>
+<%= form_with(model: Tag.new, url: tag_path, id: "new_proposition_category_tag") do |form| %>
 <% end %>
-<%= form_with(model: tag, url: tag_path, id: "new_request_category_tag") do |form| %>
+<%= form_with(model: Tag.new, url: tag_path, id: "new_request_category_tag") do |form| %>
 <% end %>
 
 <script>

--- a/app/views/propositions/edit.html.erb
+++ b/app/views/propositions/edit.html.erb
@@ -8,7 +8,7 @@
         <h4><strong>案件編集</strong></h4>
       </div>
       <div class="col-md-12 mt-4">
-        <%= render 'propositions/proposition_form', proposition: @proposition, form_target: "new_proposition", tag: @tag, submit_value: "編集完了" %>
+        <%= render 'propositions/proposition_form', proposition: @proposition, form_url: proposition_path(@proposition.id), submit_value: "編集完了" %>
       </div>
     </div>
   </div>

--- a/app/views/propositions/new.html.erb
+++ b/app/views/propositions/new.html.erb
@@ -8,7 +8,7 @@
         <h4><strong>新規案件作成</strong></h4>
       </div>
       <div class="col-md-12 mt-4">
-        <%= render 'propositions/proposition_form', proposition: @proposition, form_target: "new_proposition", tag: @tag, submit_value: "新規作成" %>
+        <%= render 'propositions/proposition_form', proposition: @proposition, form_url: propositions_path, submit_value: "新規作成" %>
       </div>
     </div>
   </div>

--- a/app/views/propositions/offer.html.erb
+++ b/app/views/propositions/offer.html.erb
@@ -5,40 +5,42 @@
     </div>
   </div>
 
-  <%# attachmentがpropositionにしか設定されておらず、offerフォームに入れるとエラーが出るため、propositionフォームを入れ子に %>
-  <%# id: "new_proposition"を付けて、propositionフォームで使用。 %>
-  <%# Rails5.2からid, classが自動付与されるはずだが、何故かidが付与されていなかった。 %>
-  <%= form_with model: [@offered_proposition, @offer], id: "new_proposition_offer"  do |f| %>
-    <%# 申請用に案件を新規作成するか、既にある案件から申請するかをラジオボタンで選択 %>
-    <div class="form-check">
-      <%= f.radio_button :radio_number, 1, checked: "checked", class: "form-check-input" %>
-      <%= f.label :radio_number, "案件を新規に作成して申請する", value: 1, class: "form-check-label" %>
+  <div class="row">
+    <label class="mt-3 mb-5"><input type="radio" name="offerFrom" onclick="offerChange();" checked="checked" />案件を新規に作成して申請する</label>
+    <label class="ml-5 mt-3 mb-5"><input type="radio" name="offerFrom" onclick="offerChange();" />既存の案件から申請する</label>
+    <div id="new-proposition-form-box" class="col-md-12">
+      <%= render 'propositions/proposition_form', proposition: @new_proposition, form_url: proposition_offers_path(@offered_proposition.id), submit_value: "申請" %>
     </div>
-
-    <div class="form-check">
-      <%= f.radio_button :radio_number, 2, class: "form-check-input" %>
-      <%= f.label :radio_number, "既存の案件から申請する", value: 2, class: "form-check-label" %>
-    </div>
-
-    <%# 案件新規作成フォーム %>
-    <%= render 'propositions/proposition_form', proposition: @new_proposition, form_target: "new_proposition_offer", tag: @tag, submit_value: "申請" %>
-
-    <%# 既存の案件リスト %>
-    <% @propositions.each do |proposition| %>
-      <div class="col-md-12 bg-light rounded p-2 mt-2">
-        <%= render 'layouts/matching_relation_info', my_proposition: proposition, opponent_proposition: @offered_proposition %>
-        <%= render 'propositions/proposition_simple_card', proposition: proposition, favorite: Favorite.find_by(user_id: current_user.id, proposition_id: proposition.id) %>
-        <div class="row">
-          <div class="col-md-10">
-          </div>
-          <div class="col-md-2">
-            <%# nameを設定しないとどの案件の「申請」ボタンが押されたのか判別がつかない。 %>
-            <%# nameを設定することでparams[:proposition.id] => "申請"となり、判別が付くようになる。 %>
-            <%= f.submit "申請", name: "#{proposition.id}", data: { disable_with: "申請中…" }, class: "btn btn-primary btn-block", form: "new_proposition_offer" %>
+    <div id="existing-proposition-form-box" class="col-md-12">
+      <% @propositions.each do |proposition| %>
+        <div class="col-md-12 bg-light rounded p-2 mt-2">
+          <%= render 'layouts/matching_relation_info', my_proposition: proposition, opponent_proposition: @offered_proposition %>
+          <%= render 'propositions/proposition_simple_card', proposition: proposition, favorite: Favorite.find_by(user_id: current_user.id, proposition_id: proposition.id) %>
+          <div class="row">
+            <div class="col-md-10">
+            </div>
+            <div class="col-md-2">
+              <%= link_to "申請", proposition_offers_path(@offered_proposition.id, offering_proposition_id: proposition.id), method: :post, class: "btn btn-primary btn-block" %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+  </div>
 
-  <% end %>
+
+  <script type="text/javascript">
+    function offerChange(){
+      radio = document.getElementsByName('offerFrom')
+      if(radio[0].checked) {
+        document.getElementById('new-proposition-form-box').style.display = "";
+        document.getElementById('existing-proposition-form-box').style.display = "none";
+      }else if(radio[1].checked) {
+        document.getElementById('new-proposition-form-box').style.display = "none";
+        document.getElementById('existing-proposition-form-box').style.display = "";
+      }
+    }
+    //オンロードさせ、リロード時に選択を保持
+    window.onload = offerChange;
+  </script>
 </div>


### PR DESCRIPTION
案件申請ページ全体を一つのフォームにしていたことにより、既存の案件の申請ボタンを押してもエラーチェックが起動してしまっていたので大幅に仕様を変更。
正しく機能すること、ページ遷移確認済み。