### PR TITLE
close #22 [finish]氏名、ヨミガナで姓と名の間に全角スペースを必ず入れるようバリデーションを付ける

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,9 +48,12 @@ class User < ApplicationRecord
   }
 
   with_options presence: true do
-    validates :name
-    validates :kana_name
     validates :user_status
+
+    with_options format: { with: /\A(.+?)\p{blank}+(.+)\z/ } do
+      validates :name
+      validates :kana_name
+    end
 
     with_options uniqueness: true do
       validates :phone_number, format: { with: /\A\d{10,11}\z/ }

--- a/app/views/users/_user_edit_form.html.erb
+++ b/app/views/users/_user_edit_form.html.erb
@@ -4,7 +4,7 @@
     <div class="col-md-10">
       <%= f.text_field :name, autofocus: true, id: "validationCustom01", class: "form-control", required: true %>
       <div class="invalid-feedback">
-        氏名を入力してください。
+        有効な氏名を入力してください。
       </div>
     </div>
   </div>
@@ -14,7 +14,7 @@
     <div class="col-md-10">
       <%= f.text_field :kana_name, id: "validationCustom02", class: "form-control", required: true %>
       <div class="invalid-feedback">
-        フリガナを入力してください。
+        有効なフリガナを入力してください。
       </div>
     </div>
   </div>
@@ -24,7 +24,7 @@
     <div class="col-md-10">
       <%= f.email_field :email, autocomplete: "email", id: "validationCustom03", class: "form-control", required: true %>
       <div class="invalid-feedback">
-        Eメールアドレスを入力してください。
+        有効なEメールアドレスを入力してください。
       </div>
     </div>
   </div>
@@ -34,7 +34,7 @@
     <div class="col-md-10">
       <%= f.text_field :phone_number, placeholder: "ハイフン無し", id: "validationCustom04", class: "form-control", required: true %>
       <div class="invalid-feedback">
-        電話番号を入力してください。
+        有効な電話番号を入力してください。
       </div>
     </div>
   </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,14 +6,13 @@
   </div>
 
   <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), html: { class: "needs-validation", novalidate: true }, local: true) do |f| %>
-
     <div class="form-group row">
       <%# nameカラム %>
       <%= f.label :name, "氏名", for: "validationCustom01", class: "col-md-2 col-form-label" %><br >
       <div class="col-md-4">
         <%= f.text_field :name, autofocus: true, placeholder: "姓と名の間に要スペース", id: "validationCustom01", class: "form-control", required: true %>
         <div class="invalid-feedback">
-          氏名を入力してください。
+          有効な氏名を入力してください。
         </div>
       </div>
       <%# kana_nameカラム %>
@@ -21,7 +20,7 @@
       <div class="col-md-4">
         <%= f.text_field :kana_name, placeholder: "姓と名の間に要スペース", id: "validationCustom02", class: "form-control", required: true %>
         <div class="invalid-feedback">
-          フリガナを入力してください。
+          有効なフリガナを入力してください。
         </div>
       </div>
     </div>
@@ -32,7 +31,7 @@
       <div class="col-md-10">
         <%= f.email_field :email, autocomplete: "email", id: "validationCustom03", class: "form-control", required: true %>
         <div class="invalid-feedback">
-          Eメールアドレスを入力してください。
+          有効なEメールアドレスを入力してください。
         </div>
       </div>
     </div>
@@ -43,7 +42,7 @@
       <div class="col-md-10">
         <%= f.text_field :phone_number, placeholder: "ハイフン無し", id: "validationCustom04", class: "form-control", required: true %>
         <div class="invalid-feedback">
-          電話番号を入力してください。
+          有効な電話番号を入力してください。
         </div>
       </div>
     </div>


### PR DESCRIPTION
・nameとkana_nameカラムにスペースを必須とする正規表現のバリデーションを追加。
・新規登録ページ、ユーザー編集ページのエラーメッセージで、正規表現のバリデーションが効いている項目には「有効な」を追加。