### PR TITLE
[finish]案件詳細ページのレイアウトを修正。

### DIFF
--- a/app/controllers/propositions_controller.rb
+++ b/app/controllers/propositions_controller.rb
@@ -10,7 +10,10 @@ class PropositionsController < ApplicationController
     @propositions = @search.result.includes(
       :proposition_category_tags,
       :request_category_tags,
-    ).joins(:user).where(users: { user_status: 1 }).page(params[:page]).per(8).reverse_order
+    ).joins(:user).where(
+      barter_status: 1..2,
+      users: { user_status: 1 },
+    ).page(params[:page]).per(8).reverse_order
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,10 @@ class UsersController < ApplicationController
     @propositions = @search.result.includes(
       :proposition_category_tags,
       :request_category_tags,
-    ).joins(:user).where(users: { user_status: "subscribing" }).shuffle.first(5)
+    ).joins(:user).where(
+      barter_status: 1..2,
+      users: { user_status: "subscribing" },
+    ).shuffle.first(5)
   end
 
   def index

--- a/app/views/favorites/_favorite_button.html.erb
+++ b/app/views/favorites/_favorite_button.html.erb
@@ -1,5 +1,5 @@
 <% if not user_signed_in? %>
-  <i class="fas fa-folder-minus fa-lg" style="color: #AF971A;"></i><span class="h5" style="color: #AF971A;"> <%= proposition.favorites.size %></span>
+  <i class="fas fa-folder fa-lg" style="color: #C0C0C0;"></i><span class="h5" style="color: #C0C0C0;"> <%= proposition.favorites.size %></span>
 <% elsif favorite.present? %>
   <%= link_to proposition_favorite_path(proposition.id, favorite.id ), method: :delete, remote: true do %>
     <i class="fas fa-folder-minus fa-lg" style="color: #AF971A;"></i><span class="h5" style="color: #AF971A;"> <%= proposition.favorites.size %></span>

--- a/app/views/layouts/_matching_relation_info.html.erb
+++ b/app/views/layouts/_matching_relation_info.html.erb
@@ -1,27 +1,27 @@
 <% if my_proposition.blank? || opponent_proposition.blank?%>
   <%# 何も表示しない。 %>
 <% elsif opponent_proposition.bartered? && opponent_proposition.offering == my_proposition %>
-  <div class="col-md-7 p-1 bg-primary text-white rounded-lg text-center">
+  <span class="p-1 bg-primary text-white rounded-lg text-center">
     スキル交換完了
-  </div>
+  </span>
 <% elsif my_proposition.bartering? && my_proposition.offering == opponent_proposition %>
-  <div class="col-md-7 p-1 text-primary border border-primary rounded-lg text-center">
+  <span class="p-1 text-primary border border-primary rounded-lg text-center">
     交換完了申請中
-  </div>
+  </span>
 <% elsif opponent_proposition.bartering? && opponent_proposition.offering == my_proposition %>
-  <div class="col-md-7 p-1 bg-warning rounded-lg text-center">
+  <span class="p-1 bg-warning rounded-lg text-center">
     交換完了申請受託中
-  </div>
+  </span>
 <% elsif opponent_proposition.matched? && opponent_proposition.offering == my_proposition %>
-  <div class="col-md-7 p-1 bg-success text-white rounded-lg text-center">
+  <span class="p-1 bg-success text-white rounded-lg text-center">
     マッチング済
-  </div>
+  </span>
 <% elsif my_proposition.offering? && my_proposition.offering == opponent_proposition %>
-  <div class="col-md-7 p-1 text-success border border-success rounded-lg text-center">
+  <span class="p-1 text-success border border-success rounded-lg text-center">
     スキル交換申請中
-  </div>
+  </span>
 <% elsif opponent_proposition.offering? && opponent_proposition.offering == my_proposition %>
-  <div class="col-md-7 p-1 bg-warning rounded-lg text-center">
+  <span class="p-1 bg-warning rounded-lg text-center">
     スキル交換申請受託中
-  </div>
+  </span>
 <% end %>

--- a/app/views/propositions/_barter_status_badge.html.erb
+++ b/app/views/propositions/_barter_status_badge.html.erb
@@ -1,6 +1,6 @@
 <% case proposition.barter_status_before_type_cast %>
 <% when 3 %>
-  <span class="h5 bg-success text-white float-right mr-3 rounded p-1">マッチ済</span>
+  <span class="h6 bg-success text-white mr-1 p-1"><strong>マッチ済</strong></span>
 <% when 4..5 %>
-  <span class="h5 bg-primary text-white float-right mr-3 rounded p-1">スキル交換完了</span>
+  <span class="h6 bg-primary text-white mr-1 p-1"><strong>スキル交換完了</strong></span>
 <% end %>

--- a/app/views/propositions/_barter_status_badge.html.erb
+++ b/app/views/propositions/_barter_status_badge.html.erb
@@ -1,0 +1,6 @@
+<% case proposition.barter_status_before_type_cast %>
+<% when 3 %>
+  <span class="h5 bg-success text-white float-right mr-3 rounded p-1">マッチ済</span>
+<% when 4..5 %>
+  <span class="h5 bg-primary text-white float-right mr-3 rounded p-1">スキル交換完了</span>
+<% end %>

--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -5,12 +5,14 @@
       <% proposition.proposition_categories.each do |proposition_category| %>
         <%= render 'tags/tag_badge', tag: proposition_category.tag %>
       <% end %>
-      <%# ストックボタン %>
+      <%# ストックボタン。交換が完了したものには表示しない。 %>
       <% if not proposition.bartered? %>
         <span id="favorite-<%= proposition.id %>" class="float-right">
           <%= render 'favorites/favorite_button', favorite: favorite, proposition: proposition %>
         </span>
       <% end %>
+      <%# 交換ステータス %>
+      <%= render 'propositions/barter_status_badge', proposition: proposition %>
     </p>
     <%# 案件タイトル %>
     <h4 class="card-title">

--- a/app/views/propositions/_proposition_detail.html.erb
+++ b/app/views/propositions/_proposition_detail.html.erb
@@ -1,5 +1,13 @@
 <div class="card bg-white border border-white">
-  <div class="card-body px-2 py-3">
+  <div class="card-body py-2 px-3">
+    <p class="card-title">
+      <%# 交換ステータス %>
+      <%= render 'propositions/barter_status_badge', proposition: proposition %>
+      <%# マッチングしている場合はマッチング相手を表示 %>
+      <% if proposition.is_matched? %>
+        <%= link_to proposition.offering.title, proposition_path(proposition.offering), class: "text-secondary" %>
+      <% end %>
+    </p>
     <%# 案件カテゴリタグ %>
     <p class="card-title">
       <% proposition.proposition_categories.each do |proposition_category| %>
@@ -11,8 +19,6 @@
           <%= render 'favorites/favorite_button', favorite: favorite, proposition: proposition %>
         </span>
       <% end %>
-      <%# 交換ステータス %>
-      <%= render 'propositions/barter_status_badge', proposition: proposition %>
     </p>
     <%# 案件タイトル %>
     <h4 class="card-title">
@@ -37,7 +43,7 @@
     </div>
 
     <%# 案件説明文 %>
-    <p class="card-text"><%= proposition.introduction %></p>
+    <p class="card-title"><%= proposition.introduction %></p>
 
     <%# 納期。交換完了申請後は表示しない %>
     <% if proposition.deadline && !proposition.is_bartering? %>
@@ -54,38 +60,14 @@
       </p>
     <% end %>
 
-    <%# 既にスキル交換申請済みの場合は申請している自分の案件名を表示 %>
-    <% if proposition.offering_to? %>
-      <p class="card-text">
-        <span class="bg-success text-light p-1">スキル交換申請中</span>
-        案件名：　
-        <%= offering_proposition.title %>
-        <%= offering_proposition.created_at.strftime("%Y/%m/%d %H:%M作成")%>
-      </p>
-    <% end %>
-
-    <%# 条件の入れ子は好ましくないが、どうしてもここは入れ子以外では表現できなかった。後程変更予定。 %>
-    <div class="actions text-center card-text mb-3">
-      <%# ログインしていない場合は何も表示しない。 %>
-      <% if not user_signed_in? %>
+    <div class="actions text-center col-md-10 offset-md-1 mb-3">
       <%# 自分の案件には案件編集ページ %>
-      <% elsif proposition.user == current_user %>
+      <% if user_signed_in? && proposition.user == current_user %>
         <%= link_to "編集する", edit_proposition_path(proposition.id), class: "btn btn-success btn-block" %>
         <%= link_to "削除する", proposition_path(proposition.id), method: :delete, class: "btn btn-outline-danger btn-block" %>
-      <% elsif proposition.is_matched? %>
-        <%# 案件がマッチング済みで、マッチングしているのも自分 %>
-        <% if proposition.matched_with? %>
-          <%= link_to "交換申請を取り下げる",  proposition_offer_path(proposition.id, offering_proposition.offering_relationship.id), method: :delete, class: "btn btn-outline-danger btn-block" %>
-        <%# 案件がマッチング済みだが、マッチングしているのは他人である場合は何も表示しない %>
-        <% end %>
-      <% else %>
-        <%# 案件はマッチングしていなくて、自分が交換申請を出している場合 %>
-        <% if proposition.offering_to? %>
-          <%= link_to "交換申請を取り下げる",  proposition_offer_path(proposition.id, offering_proposition.offering_relationship.id), method: :delete, class: "btn btn-outline-danger btn-block" %>
-        <%# 案件はマッチングしていなくて、自分が交換申請を出していない場合 %>
-        <% else %>
-          <%= link_to "スキル交換申請", offer_propositions_path(offered_id: proposition.id), class: "btn btn-info btn-block"%>
-        <% end %>
+      <%# 自分が申請を出していない案件なら申請ボタン %>
+      <% elsif user_signed_in? && (not proposition.offering_to?) %>
+        <%= link_to "スキル交換申請", offer_propositions_path(offered_id: proposition.id), class: "btn btn-info btn-block"%>
       <% end %>
     </div>
 

--- a/app/views/propositions/mypage_index.html.erb
+++ b/app/views/propositions/mypage_index.html.erb
@@ -36,7 +36,9 @@
                 <%# 自分が申請を出している相手がいればそれが一番上 %>
                 <% if proposition.offering %>
                   <div class="col-md-12 my-2 p-0">
-                    <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition, opponent_proposition: proposition.offering %>
+                    <p class="mb-1">
+                      <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition, opponent_proposition: proposition.offering %>
+                    </p>
                     <%= render 'propositions/proposition_card', proposition: proposition.offering %>
                   </div>
                 <% end %>
@@ -44,8 +46,10 @@
                   <%# 申請相手は上記で表示しているので、ここには表示させたくない。 %>
                   <% if not (proposition.offering.present? && proposition.offering == offering_proposition) %>
                     <div class="col-md-12 my-2 p-0">
-                      <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition, opponent_proposition: offering_proposition %>
-                      <%= render 'propositions/proposition_card', proposition: offering_proposition %>
+                      <p class="mb-1">
+                        <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition, opponent_proposition: offering_proposition %>
+                        <%= render 'propositions/proposition_card', proposition: offering_proposition %>
+                      </p>
                     </div>
                   <% end %>
                 <% end %>

--- a/app/views/propositions/show.html.erb
+++ b/app/views/propositions/show.html.erb
@@ -3,6 +3,29 @@
     <div class="col-md-12">
       <h4><strong>案件詳細</strong></h4>
     </div>
+    <% if user_signed_in? && @proposition.offering_to? %>
+      <div class="mr-auto mb-3 rounded border border-secondary mx-4 p-2">
+        <div class="row">
+          <div class="col-md-12">
+            <p class="mb-1">
+              <% my_proposition = @proposition.my_offering_proposition %>
+              あなたとの関係：
+              <%= render 'layouts/matching_relation_info', opponent_proposition: @proposition, my_proposition: my_proposition %>
+            </p>
+            <p class="mb-1">
+              <%= link_to proposition_path(my_proposition.id) do %>
+                <strong class="mr-3"><%= my_proposition.title %></strong><br >
+                <%= my_proposition.created_at.strftime("%Y/%m/%d %H:%M作成")%>
+              <% end %>
+            </p>
+            <% if (not @proposition.is_reviewed?) && @proposition.offering_to? %>
+              <%= link_to "交換申請を取り下げる",  proposition_offer_path(@proposition.id, my_proposition.offering_relationship.id), method: :delete, class: "btn btn-danger p-1" %>
+            <% else %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
 
   <div class="row">

--- a/app/views/users/favorites.html.erb
+++ b/app/views/users/favorites.html.erb
@@ -26,7 +26,9 @@
             <div class="row">
               <%# お気に入り案件一覧 %>
               <div class="col-md-5 my-2">
-                <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition.my_offering_proposition, opponent_proposition: proposition %>
+                <p class="mb-1">
+                  <%= render 'layouts/matching_relation_info.html.erb', my_proposition: proposition.my_offering_proposition, opponent_proposition: proposition %>
+                </p>
                 <%= render 'propositions/proposition_card', proposition: proposition %>
               </div>
               <div class="col-md-2">


### PR DESCRIPTION
案件詳細ページについて
・申請している自分の案件の情報と申請取り消しボタンを上部に表示
・案件カード右上部に交換ステータスバッジを表示
・案件申請ボタンの表示・非表示ロジックを修正
・要望カテゴリを下部に移動

併せて
マイ案件、ストック案件一覧ページの交換ステータスバッジ表示位置を修正