### PR TITLE
[add]header_specを追加

### DIFF
--- a/app/views/layouts/_not_logged_in_header.html.erb
+++ b/app/views/layouts/_not_logged_in_header.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-md bg-white rounded-bottom fixed-top py-0">
   <div class="container">
     <%= link_to root_path, class: "navbar-brand" do %>
-      <%= image_tag 'skill_barter_logo.jpg', width: 70, height: 70 %>
+      <%= image_tag 'skill_barter_logo.jpg', width: 70, height: 70, alt: "skill_barter_logo" %>
     <% end %>
 
     <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navbar" aria-controls="Navbar" aria-expanded="false" aria-label="ナビゲーションの切替">

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe "Header", type: :system do
+  let(:user) { create(:user) }
+
+  describe "ログインしていない場合" do
+    before do
+      visit root_path
+    end
+
+    context "ヘッダーの表示を確認" do
+      it "ロゴが表示される" do
+        pending "表示されているはずだが、何故が存在しないと言われる。"
+        expect(page).to have_selector("img[src$='skill_barter_logo']")
+      end
+      it "ロゴがトップページへのリンクになっている" do
+        click_on "skill_barter_logo"
+        expect(current_path).to eq root_path
+      end
+      it "ログインリンクが表示される。" do
+        click_on "ログイン"
+        expect(current_path).to eq new_user_session_path
+      end
+      it "新規登録リンクが表示される。" do
+        click_on "新規登録"
+        expect(current_path).to eq new_user_registration_path
+      end
+    end
+  end
+
+  describe "ログインしている場合" do
+    before do
+      visit new_user_session_path
+      fill_in "user[email]", with: user.name
+      fill_in "user[password]", with: user.password
+      within ".actions" do
+        click_on "ログイン"
+      end
+    end
+
+    context "ヘッダーの表示を確認" do
+      it "ロゴが表示される" do
+        pending "表示されているはずだが、何故が存在しないと言われる。"
+        expect(page).to have_selector("img[src$='skill_barter_logo']")
+      end
+      it "ロゴがトップページへのリンクになっている" do
+        click_on "skill_barter_logo"
+        expect(current_path).to eq root_path
+      end
+      it "マイページリンクが表示される。" do
+        click_on "マイページ"
+        expect(current_path).to eq mypage_users_path
+      end
+      it "ログアウトリンクが表示される。" do
+        click_on "ログアウト"
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
ログイン時、未ログイン時のヘッダー要素のテストを追加。

・ロゴの画像が認識されない。
・new_user_session_pathで必要事項を入力してログインボタンを押しても(おそらく)ログインできていないので、ログインのテストは要対応。